### PR TITLE
Update PHP versions for 2026-08

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Five different images for each PHP Version:
 
 |  Version   |  Latest Version  | Monthly Builds |  Alpine Version  |
 |:----------:|:----------------:|:--------------:|:----------------:|
-| **8.6** ⚠ | **8.6.0alpha3**  |    **yes**     | **edge/testing** |
+| **8.6** ⚠ | **8.6.0beta1**   |    **yes**     | **edge/testing** |
 |  **8.5**   |    **8.5.9**     |    **yes**     |     **edge**     |
 |  **8.4**   |    **8.4.24**    |    **yes**     |     **edge**     |
 |  **8.3**   |    **8.3.33**    |    **yes**     |     **edge**     |
@@ -82,7 +82,7 @@ Five different images for each PHP Version:
 |    7.0     |      7.0.33      |       -        |       3.5        |
 |    5.6     |      5.6.40      |       -        |       3.8        |
 
-⚠ PHP 8.6 is a **pre-release** (alpha). The images are meant for early testing only and do not
+⚠ PHP 8.6 is a **pre-release** (beta). The images are meant for early testing only and do not
 ship the `redis`, `memcached` and `yaml` extensions yet, since Alpine has not published them for
 PHP 8.6.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -158,7 +158,7 @@ To balance security with stability:
 
 ### Why Edge/Testing for PHP 8.6?
 
-PHP 8.6 has not been released yet — Alpine ships it as `8.6.0_alphaX` in the `edge/testing`
+PHP 8.6 has not been released yet — Alpine ships it as `8.6.0_betaX` in the `edge/testing`
 repository, which is the only Alpine repository carrying PHP 8.6 packages.
 
 **Do not use PHP 8.6 in production** until it reaches a stable release. These images exist for:


### PR DESCRIPTION
## Summary

Monthly PHP version check for August 2026.

| Branch | php.net | php.watch | Alpine (edge) | In matrix |
|---|---|---|---|---|
| 8.6 | not yet released | upcoming (beta) | `php86` 8.6.0_beta1 (edge/testing) | yes |
| 8.5 | Active Support | Supported | `php85` 8.5.9 (edge/community) | yes |
| 8.4 | Active Support | Supported | `php84` 8.4.24 (edge/community) | yes |
| 8.3 | Security fixes only | Security-fixes only | `php83` 8.3.33 (edge/community) | yes |
| 8.2 | Security fixes only | Security-fixes only | frozen (excluded by policy) | no (frozen) |

## Changes

- README.md: PHP 8.6 latest version `8.6.0alpha3` -> `8.6.0beta1`; pre-release note updated from "(alpha)" to "(beta)".
- docs/security.md: updated the `8.6.0_alphaX` reference to `8.6.0_betaX` to match.

No other version numbers changed — 8.5 (8.5.9), 8.4 (8.4.24), and 8.3 (8.3.33) already match what Alpine `edge/community` currently ships. No branches were added or removed. `php86-redis`, `php86-pecl-memcached` and `php86-pecl-yaml` are still not published by Alpine, so `config/php-8.6.yml` keeps those extensions commented out.

## Test plan

- [x] Verified via Alpine `edge/community` and `edge/testing` APKINDEX that the versions above are accurate.
- [x] `python3 ./build.py 8.6 --build-base --build-cli --build-fpm --build-fpm-apache --build-fpm-nginx --build-nginx` generates all six `Dockerfile-php-8.6-*` files successfully.
- [ ] Docker image build — not available in this sandbox (no Docker daemon); relying on PR CI (`Build-Base`) to validate.


---
_Generated by [Claude Code](https://claude.ai/code/session_019RgsLoQXMdvekp9dFZb2m2)_